### PR TITLE
Stripe edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1210,7 +1210,7 @@ _Note to readers: This list refers to some of the articles, posts, videos, tools
 ### Blog Posts
 
 * [Fast and flexible observability with canonical log lines](https://stripe.com/blog/canonical-log-lines)
-* [Introducing Veneur: high performance and global aggregation for Datadog](https://stripe.com/blog/engineering/page/3)
+* [Introducing Veneur: high performance and global aggregation for Datadog](https://stripe.com/blog/introducing-veneur-high-performance-and-global-aggregation-for-datadog)
 
 ### Videos
 

--- a/README.md
+++ b/README.md
@@ -1210,6 +1210,7 @@ _Note to readers: This list refers to some of the articles, posts, videos, tools
 ### Blog Posts
 
 * [Fast and flexible observability with canonical log lines](https://stripe.com/blog/canonical-log-lines)
+* [Fast builds, secure builds. Choose two.](https://stripe.com/blog/fast-secure-builds-choose-two)
 * [Introducing Veneur: high performance and global aggregation for Datadog](https://stripe.com/blog/introducing-veneur-high-performance-and-global-aggregation-for-datadog)
 
 ### Videos


### PR DESCRIPTION
This PR contains the following cases under **Stripe**:
- A link correction for their post on the Veneur aggregator, as it had targeted a results page, not the blog post itself.
- A new blog post related to their CI/CD build considerations.